### PR TITLE
Update study area to account for exclusion zones

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -38,10 +38,17 @@ scope:
         - "Serbia"
         - "Switzerland"
     bounds:
-        x_min: -15.8 # in degrees east
+        x_min: -30 # in degrees east
         x_max: 37  # in degrees east
         y_min: 30  # in degrees north
         y_max: 75  # in degrees north
+    exclusion_zones:
+        atlantic_islands:
+            x_min: -29.5 # in degrees east
+            x_max: -15  # in degrees east
+            y_min: 31  # in degrees north
+            y_max: 41  # in degrees north
+
 layers:
     continental:
         Austria: nuts0

--- a/src/lau.py
+++ b/src/lau.py
@@ -7,8 +7,8 @@ import geopandas as gpd
 import pandas as pd
 import pycountry
 
-from gadm import SCHEMA, _test_id_uniqueness
-from nuts import _to_multi_polygon, _study_area
+from gadm import SCHEMA, _test_id_uniqueness, _study_area
+from nuts import _to_multi_polygon
 from conversion import eu_country_code_to_iso3
 from utils import Config
 

--- a/src/nuts.py
+++ b/src/nuts.py
@@ -7,7 +7,7 @@ import geopandas as gpd
 import pandas as pd
 import pycountry
 
-from gadm import SCHEMA, _to_multi_polygon, _test_id_uniqueness
+from gadm import SCHEMA, _to_multi_polygon, _test_id_uniqueness, _study_area
 from conversion import eu_country_code_to_iso3
 from utils import Config
 
@@ -112,15 +112,6 @@ def _in_layer(layer_id, feature):
         return True
     else:
         return False
-
-
-def _study_area(config):
-    return shapely.geometry.box(
-        minx=config["scope"]["bounds"]["x_min"],
-        maxx=config["scope"]["bounds"]["x_max"],
-        miny=config["scope"]["bounds"]["y_min"],
-        maxy=config["scope"]["bounds"]["y_max"]
-    )
 
 
 def _in_study_area(config, feature):


### PR DESCRIPTION
Now an arbitrary number of exclusion zones can be defined in the model scope. These can only be rectangular.

I can't test this on the whole workflow, since I have eternal package conflicts, but the defined 'atlantic islands'  exclusion zone leads to the following study area:

![image](https://user-images.githubusercontent.com/17178478/84643080-42410780-aef5-11ea-93fd-d829f15d7f69.png)

If defining a polygon that fits within the exclusion zone (e.g. `small_hole = shapely.geometry.Polygon(((-25, 35), (-24, 35), (-24, 40), (-25, 40)))`), then `study_area.intersects(small_hole)` and `study_area.contains(small_hole)` are both False.

If defining a polygon that partially fits within the exclusion zone (e.g. `big_hole = shapely.geometry.Polygon(((-25, 35), (-10, 35), (-10, 45), (-25, 45)))`), then `study_area.intersects(big_hole) == True` and `study_area.contains(big_hole) == False`.

<details><summary>MWE</summary>
<p>

```python
import shapely.geometry
import shapely.errors
import geopandas as gpd

def _study_area(config):
    """
    Create a bounding box for the study area, and cut out holes for all defined
    exclusion zones. For plotting purposes, exclusion zones and the bounding box are
    defined in opposite orientations, see https://github.com/geopandas/geopandas/issues/951
    """
    if config["scope"].get("exclusion_zones", {}) and isinstance(config["scope"]["exclusion_zones"], dict):
        holes = [
            (
                (exclusion_zone["x_max"], exclusion_zone["y_min"]),
                (exclusion_zone["x_max"], exclusion_zone["y_max"]),
                (exclusion_zone["x_min"], exclusion_zone["y_max"]),
                (exclusion_zone["x_min"], exclusion_zone["y_min"])
            )
            for exclusion_zone in config["scope"]["exclusion_zones"].values()
        ]
    else:
        holes = []

    study_area = shapely.geometry.Polygon(
        ((config["scope"]["bounds"]["x_min"], config["scope"]["bounds"]["y_min"]),
         (config["scope"]["bounds"]["x_min"], config["scope"]["bounds"]["y_max"]),
         (config["scope"]["bounds"]["x_max"], config["scope"]["bounds"]["y_max"]),
         (config["scope"]["bounds"]["x_max"], config["scope"]["bounds"]["y_min"])),
        holes=holes
    )

    if study_area.is_valid is False:
        raise shapely.errors.TopologicalError(
            "Invalid study area geometry. "
            "Ensure that exclusion zones do not share a border with the study bounds."
        )
    else:
        return study_area

config = {'scope':{
    'bounds': {
        'x_min': -30, # in degrees east
        'x_max': 37,  # in degrees east
        'y_min': 30,  # in degrees north
        'y_max': 75,  # in degrees north
    },
    'exclusion_zones':{
        'atlantic_islands':{
            'x_min': -29.5, # in degrees east
            'x_max': -15,  # in degrees east
            'y_min': 31,  # in degrees north
            'y_max': 41  # in degrees north
        }
    }}
}

study_area = _study_area(config)

small_hole = shapely.geometry.Polygon(((-25, 35), (-24, 35), (-24, 40), (-25, 40)))
big_hole = shapely.geometry.Polygon(((-25, 35), (-10, 35), (-10, 45), (-25, 45)))

print(
    "contains small hole:", foo.contains(small_hole)
    "intersects small hole:", foo.intersects(small_hole)
    "contains big hole:", foo.contains(big_hole)
    "intersects big hole:", foo.intersects(big_hole)
)

```

</p>
</details>